### PR TITLE
Fixes #80. Warnings related to the browserslist package

### DIFF
--- a/generators/app/templates/.browserslistrc
+++ b/generators/app/templates/.browserslistrc
@@ -1,0 +1,3 @@
+# Browsers that are supported
+
+last 4 versions

--- a/generators/app/templates/gulp/tasks/sass.js
+++ b/generators/app/templates/gulp/tasks/sass.js
@@ -28,7 +28,7 @@ const sortMediaQueries = (a, b) => {
 
 const processors = [
   autoprefixer({
-    browsers: ['last 4 versions'],
+    // browsers: ['last 4 versions'],
     cascade: false
   }),
   // require('lost'),


### PR DESCRIPTION
Solution:
1. Remove autoprefixer browsers option
2. Create .browserslistrc

Issue:
I'm getting a series of warnings related to the browserslist package
```
Replace Autoprefixer browsers option to Browserslist config.
Use browserslist key in package.json or .browserslistrc file.

Using browsers option cause some error. Browserslist config
can be used for Babel, Autoprefixer, postcss-normalize and other tools.

If you really need to use option, rename it to overrideBrowserslist.

Learn more at:
https://github.com/browserslist/browserslist#readme
https://twitter.com/browserslist
```
os: windows 10
npm: 6.10.0
gulp: CLI version: 2.2.0, Local version: 4.0.2 